### PR TITLE
Allow Alt and Meta keys to have default behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,7 +439,7 @@ addEventListener('keydown', (e) => {
   if (e.target && e.target.tagName === 'INPUT' && e.target.type === 'text')
     return
 
-  const { key, ctrlKey, altKey, shiftKey } = e
+  const { key, ctrlKey, metaKey, shiftKey } = e
   console.log(key)
 
   if (key === 'Tab') {
@@ -461,7 +461,7 @@ addEventListener('keydown', (e) => {
     return
   }
 
-  if (ctrlKey || altKey) return
+  if (ctrlKey || metaKey) return
 
   if (key === ' ') {
     e.preventDefault()


### PR DESCRIPTION
Currently the Meta key and Alt keys have no effect on the website. This is causing two issues:
1. On Mac OS, keyboard shortcuts such as page refresh and switching tabs involve the Meta key. This makes the keyboard shortcuts unusable in the game.
2. In Kana input, punctuations ？ and ！ are typed with Alt key, so it means that these punctuations (along with others) cannot be typed in the game.

Removing the Alt key check in the code and adding the Meta key to skip handling fixes both these issues.